### PR TITLE
Not Send Mail if user banned

### DIFF
--- a/lib/categoryNotifications.js
+++ b/lib/categoryNotifications.js
@@ -8,6 +8,7 @@ var db = require.main.require('./src/database');
 var meta = require.main.require('./src/meta');
 var emailer = require.main.require('./src/emailer');
 var notifications = require.main.require('./src/notifications');
+var user = require.main.require('./src/user');
 
 var categoryNotifications = {};
 
@@ -144,7 +145,9 @@ function sendTopicEmail(topic) {
 				}
 			};
 
-		async.eachLimit(uids, 50, function(uid, next) {
+		async.eachLimit(uids, 50, async function(uid, next) {
+            const userDate = await user.getUserData(uid);
+            if (userDate.banned) return winston.verbose(`[plugins/category-notifications] uid ${uid} banned. not Send Email`);
 			emailer.send(tpl, uid, params, next);
 		}, function(err) {
 			if (err) {
@@ -198,7 +201,9 @@ function sendPostEmail(post) {
 				pid: post.pid
 			};
 
-		async.eachLimit(uids, 50, function(uid, next) {
+		async.eachLimit(uids, 50, async function(uid, next) {
+            const userDate = await user.getUserData(uid);
+            if (userDate.banned) return winston.verbose(`[plugins/category-notifications] uid ${uid} banned. not Send Email`);
 			emailer.send(tpl, uid, params, next);
 		}, function(err) {
 			if (err) {


### PR DESCRIPTION
If banning user he keeps getting emails about updates and has no way to turn it off.

I do not want to remove his listing from any while banning (like deleting) because I can return it to the forum. Therefore if it is banned the email will not be sent.